### PR TITLE
貸出編集画面・機能を追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,5 +1,7 @@
 package jp.co.metateam.library.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,6 +11,20 @@ import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
+import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.RentalManageDto;
+
+import jp.co.metateam.library.model.Account;
+import jp.co.metateam.library.model.Stock;
+import jp.co.metateam.library.values.RentalStatus;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import jakarta.validation.Valid;
+
 
 /**
  * 貸出管理関連クラスß
@@ -40,11 +56,50 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-
+        List<RentalManage> RentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
-
+        model.addAttribute("rentalManageList", RentalManageList);
         // 貸出一覧画面に遷移
-        return "";
+        return "rental/index";
     }
+    
+
+    @GetMapping("/rental/add")
+    public String add(Model model) {
+
+        List <Stock> stockList = this.stockService.findAll();
+        List <Account> accounts = this.accountService.findAll();
+
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+
+        if (!model.containsAttribute("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+ 
+        return "rental/add";
+    }
+
+    @PostMapping("/rental/add")
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+        try {
+            if (result.hasErrors()) {
+                throw new Exception("Validation error.");
+            }
+            // 登録処理
+            this.rentalManageService.save(rentalManageDto);
+ 
+            return "redirect:/rental/index";
+        } catch (Exception e) {
+            log.error(e.getMessage());
+ 
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+ 
+            return "redirect:/rental/add";
+        }
+    }
+    
 
 }

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
+    <title th:text="${title}+' | MTLibrary'"></title>
+    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+</head>
+
+<body>
+    <div class="contents">
+        <div th:replace="~{common :: main_sidebar}"></div>
+        <div class="main_contents">
+            <div th:replace="~{common :: header}"></div>
+            <div class="inner_contens">
+                <div class="page_title">貸出編集</div>
+                <div class="mb30 flexarea">
+                    <span class="text-red">＊は必須項目です</span>
+                    <span>
+                        <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
+                    </span>
+                </div>
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                    <div class="mb30">
+                        <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
+                        <select id="employeeId" class="form_input" name="employeeId" required>
+                            <option value="">社員番号を選択</option>
+                            <option th:each="account : ${accounts}" th:value="${account.employeeId}"
+                                th:text="${account.employeeId + ' ' + account.name}"
+                                th:selected="${account.employeeId == rentalManageDto.employeeId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('employeeId')}" th:errors="*{employeeId}">
+                        </div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedRentalOn">貸出予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
+                            th:value="${#dates.format(rentalManageDto.expectedRentalOn, ('yyyy-MM-dd'))}"
+                            placeholder="貸出予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
+                            th:errors="*{expectedRentalOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedReturnOn">返却予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedReturnOn" class="form_input" name="expectedReturnOn"
+                            th:value="${#dates.format(rentalManageDto.expectedReturnOn, ('yyyy-MM-dd'))}"
+                            placeholder="返却予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedReturnOn')}"
+                            th:errors="*{expectedReturnOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="stockMngNumber">在庫管理番号<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="stockMngNumber" class="form_input" name="stockId" required>
+                            <option value="">在庫管理番号を選択</option>
+                            <option th:each="stock : ${stockList}" th:value="${stock.id}"
+                                th:text="${stock.id + ' ' + stock.bookMst.title}"
+                                th:selected="${stock.id == rentalManageDto.stockId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('stockId')}" th:errors="*{stockId}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="rentalStatus">貸出ステータス<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="rentalStatus" class="form_input" name="status" required>
+                            <option value="">ステータスを選択</option>
+                            <option th:each="status : ${rentalStatus}" th:value="${status.value}"
+                                th:text="${status.text}" th:selected="${status.value == rentalManageDto.status}">
+                            </option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></div>
+                    </div>
+                    <div class="btn_block">
+                        <button type="submit" id="submit_btn">保存</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div th:replace="~{common :: footer}"></div>
+</body>


### PR DESCRIPTION
**・概要**
> 貸出編集画面（rental.edit）を追加しました。
> 貸出編集機能（RentalMangeController等）を追加しました。
> updateメソッドを追加し、貸出情報を編集し更新できるように実装しました。また、その際のバリデーションチェックについても補填しました。具体的には、貸出ステータスの変更に伴うエラーが表示されます。

**・テスト証跡**
正規の値の場合：貸出一覧画面の表示　→　リスト内の編集アイコンを押下　→　貸出編集画面の表示　→　貸出情報の編集　→　更新ボタン押下　→　貸出一覧画面へ遷移　→　更新した情報が表示されている。

誤った値の場合：貸出一覧画面の表示　→　リスト内の編集アイコンを押下　→　貸出編集画面の表示　→　貸出情報の編集　→　更新ボタン押下　→　エラーメッセージ表示（貸出一覧画面に遷移せず）

**・備考**
コードの理解を深めるため、学習内容を書き込んでいる部分がございます。ご了承いただけますと幸いです。