### PR TITLE
在庫カレンダー機能追加

### DIFF
--- a/docker/mt_library/launch.json
+++ b/docker/mt_library/launch.json
@@ -1,4 +1,4 @@
-{
+/*{
 	"version": "0.2.0",
 	"configurations": [
 		{
@@ -9,4 +9,26 @@
 			"port": 5005
 		}
 	]
+}*/
+
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Current File",
+            "request": "launch",
+            "mainClass": "${file}"
+        },
+        {
+            "type": "java",
+            "name": "MtLibraryApplication",
+            "request": "launch",
+            "mainClass": "jp.co.metateam.library.MtLibraryApplication",
+            "projectName": "MTLibrary"
+        }
+    ]
 }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,14 +1,28 @@
 package jp.co.metateam.library.controller;
 
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.validation.BindingResult;
 
 import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
+
+import jakarta.validation.Valid;
+import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.RentalManageDto;
+import jp.co.metateam.library.model.Stock; 
+import jp.co.metateam.library.model.Account; 
+import jp.co.metateam.library.model.AccountDto;
+
+import jp.co.metateam.library.values.RentalStatus;
 
 /**
  * 貸出管理関連クラスß
@@ -30,6 +44,7 @@ public class RentalManageController {
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
+
     }
 
     /**
@@ -40,11 +55,46 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
-
+        model.addAttribute("rentalManageList", rentalManageList);
         // 貸出一覧画面に遷移
-        return "";
+        return "/rental/index";
     }
 
+    @GetMapping("/rental/add")
+    public String add(Model model) {
+        List<Stock> stockList = this.stockService.findAll();
+        List<Account> accounts = this.accountService.findAll();
+
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+        model.addAttribute("accounts", accounts);
+
+        if (!model.containsAttribute("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+
+        return "rental/add";
+    }
+
+    @PostMapping("/rental/add")
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+        try {
+            if (result.hasErrors()) {
+                throw new Exception("Validation error.");
+            }
+            // 登録処理
+            this.rentalManageService.save(rentalManageDto);
+
+            return "redirect:/rental/index";
+        } catch (Exception e) {
+            log.error(e.getMessage());
+
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+
+            return "redirect:/rental/add";
+        }
+    }
 }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,52 +1,60 @@
 package jp.co.metateam.library.controller;
-
 import java.util.List;
+import java.util.Date;
+ 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.validation.BindingResult;
-
+import org.springframework.validation.FieldError;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+ 
+import jakarta.validation.Valid;
+import jp.co.metateam.library.model.Account;
+import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.Stock;
+import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.service.AccountService;
+import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
-import lombok.extern.log4j.Log4j2;
-
-import jakarta.validation.Valid;
-import jp.co.metateam.library.model.RentalManage;
-import jp.co.metateam.library.model.RentalManageDto;
-import jp.co.metateam.library.model.Stock; 
-import jp.co.metateam.library.model.Account; 
-import jp.co.metateam.library.model.AccountDto;
-
+import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.values.RentalStatus;
-
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.PathVariable;
+import jp.co.metateam.library.constants.Constants;
+import jp.co.metateam.library.repository.RentalManageRepository;
+import java.util.Optional;
+ 
+ 
 /**
  * 貸出管理関連クラスß
  */
 @Log4j2
 @Controller
 public class RentalManageController {
-
+ 
+    private final BookMstService bookMstService;
+    private final StockService stockService;
     private final AccountService accountService;
     private final RentalManageService rentalManageService;
-    private final StockService stockService;
-
+ 
     @Autowired
     public RentalManageController(
-        AccountService accountService, 
-        RentalManageService rentalManageService, 
-        StockService stockService
+        AccountService accountService,
+        RentalManageService rentalManageService,
+        StockService stockService,
+        BookMstService bookMstService
     ) {
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
-
+        this.bookMstService = bookMstService;
     }
-
+ 
     /**
      * 貸出一覧画面初期表示
      * @param model
@@ -55,46 +63,200 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
-        // 貸出一覧画面に渡すデータをmodelに追加
-        model.addAttribute("rentalManageList", rentalManageList);
+            List<RentalManage> rentalManageList = this.rentalManageService.findAll();
+        // 貸出一覧画面に渡すデータをmodelに追加    
+            model.addAttribute("rentalManageList", rentalManageList);
+ 
         // 貸出一覧画面に遷移
-        return "/rental/index";
-    }
-
+            return "rental/index";
+        }
+   
     @GetMapping("/rental/add")
-    public String add(Model model) {
-        List<Stock> stockList = this.stockService.findAll();
-        List<Account> accounts = this.accountService.findAll();
-
-        model.addAttribute("stockList", stockList);
+    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto) {
+        List <Stock> stockList = this.stockService.findAll();
+        List <Account> accounts = this.accountService.findAll();
+ 
         model.addAttribute("rentalStatus", RentalStatus.values());
+        model.addAttribute("stockList", stockList);
         model.addAttribute("accounts", accounts);
-
+ 
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
-
+ 
         return "rental/add";
     }
-
+   
+ 
     @PostMapping("/rental/add")
-    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra, Model model){
+        //バリデーションチェック
         try {
-            if (result.hasErrors()) {
+                //貸出ステータスのチェック,(rentalmanageDTOでチェック→ここで呼び出す)
+                //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
+                String stockId = rentalManageDto.getStockId();
+                Integer status = rentalManageDto.getStatus();
+                if(status == 0 || status == 1) {
+                    Long stockaddcount = this.rentalManageService.countByStockIdAndStatus(stockId);
+                        if(!(stockaddcount == 0)) {
+                            Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+                            Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+                            Long rentaladdcount = this.rentalManageService.countByStockIdAndStatusAndExpectedDates(stockId, expectedReturnOn, expectedRentalOn);
+
+                            if(!(stockaddcount==rentaladdcount)) {
+                                String rentaladdError = "この期間は貸出できません。";
+                                result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentaladdError));
+                                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentaladdError));
+                            }
+                        }
+                }
+
+                if (result.hasErrors()) {
+                    throw new Exception("Validation error.");
+                }
+                // 登録処理
+                this.rentalManageService.save(rentalManageDto);
+   
+                return "redirect:/rental/index";
+            } catch (Exception e) {
+                log.error(e.getMessage());
+
+                //変更前の貸出情報を取得
+                //RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+ 
+                //rentalManageDto.setId(rentalManageDto.getId());
+                rentalManageDto.setEmployeeId(rentalManageDto.getEmployeeId());
+                rentalManageDto.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
+                rentalManageDto.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
+                rentalManageDto.setStatus(rentalManageDto.getStatus());
+                rentalManageDto.setStockId(rentalManageDto.getStockId());
+
+                List <Stock> stockList = this.stockService.findAll();
+                List <Account> accounts = this.accountService.findAll();
+ 
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("accounts", accounts);
+ 
+                ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+                ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+   
+                return "/rental/add";
+            }
+    }
+ 
+ 
+    @GetMapping("/rental/{id}/edit")
+    public String edit(@PathVariable("id") String id, Model model) {
+ 
+        List<Account> accounts = this.accountService.findAll();
+        List <Stock> stockList = this.stockService.findStockAvailableAll();
+       
+        model.addAttribute("accounts",accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+ 
+        if (!model.containsAttribute("rentalManageDto")) {
+           
+         //DBから編集する貸出管理番号のレコードを取得する
+         RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+         
+         //レコードのデータを挿入する箱を作る
+         RentalManageDto rentalManageDto = new RentalManageDto();
+         //箱にデータを移す
+         rentalManageDto.setId(rentalManage.getId());
+         rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
+         rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
+         rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
+         rentalManageDto.setStatus(rentalManage.getStatus());
+         rentalManageDto.setStockId(rentalManage.getStock().getId());
+ 
+         model.addAttribute("rentalManageDto", rentalManageDto);
+        }
+ 
+        return "rental/edit";
+ 
+    }
+ 
+    @PostMapping("/rental/{id}/edit")
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, Model model,RedirectAttributes ra) {
+        try {
+             // 変更前の貸出情報を取得
+             RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+             // 変更前と変更後の貸出ステータスを取得
+             Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
+             // Optionalが空でない場合のみエラーを処理する
+              validErrorOptional.ifPresent(validError -> {
+                 if (!validError.isEmpty()) {
+                    result.addError(new FieldError("rentalmanageDto", "status", validError));
+                     throw new RuntimeException(validError);
+                 }
+             });
+
+              //貸出ステータスのチェック,(rentalmanageDTOでチェック→ここで呼び出す)
+             //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
+             String stockId = rentalManageDto.getStockId();
+             Long ID = rentalManage.getId();
+             Integer status = rentalManageDto.getStatus();
+
+             if(status == 0 || status == 1) {
+                    Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId,ID);
+            
+
+                  if(!(stockcount == 0)) {
+                     Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+                     Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+                     Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId,ID, expectedReturnOn, expectedRentalOn);
+
+                     if(!(stockcount==rentalcount)) {
+                         String rentalError = "この期間は貸出できません。";
+                         result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentalError));
+                         result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentalError));
+                        }
+                    }
+                }
+            
+
+             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
-            // 登録処理
-            this.rentalManageService.save(rentalManageDto);
 
-            return "redirect:/rental/index";
+             // 更新処理
+             this.rentalManageService.update(Long.valueOf(id), rentalManageDto);
+           
+             return "redirect:/rental/index";
+ 
+            //貸出ステータスのチェック(rentalmanageDTOでチェック→ここで呼び出す)
+            //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
+ 
         } catch (Exception e) {
             log.error(e.getMessage());
-
-            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
-            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
-
-            return "redirect:/rental/add";
+       
+         //変更前の貸出情報を取得
+         RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+ 
+         rentalManageDto.setId(rentalManage.getId());
+         rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
+         rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
+         rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
+         rentalManageDto.setStatus(rentalManage.getStatus());
+         rentalManageDto.setStockId(rentalManage.getStock().getId());
+ 
+         ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+         ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+ 
+         /*List<Account> accounts = this.accountService.findAll();
+         List <Stock> stockList = this.stockService.findStockAvailableAll();
+       
+         model.addAttribute("accounts",accounts);
+         model.addAttribute("stockList", stockList);
+         model.addAttribute("rentalStatus", RentalStatus.values());*/
+ 
+         //元データを再取得
+          // List <RentalManage> rentalManageList = this.rentalManageRepository.findById();
+         
+           return String.format("redirect:/rental/%s/edit",id);
         }
     }
+ 
 }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,13 +12,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.Stock;
-import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.service.RentalManageService;
@@ -26,8 +27,6 @@ import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.values.RentalStatus;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.bind.annotation.PathVariable;
-import jp.co.metateam.library.constants.Constants;
-import jp.co.metateam.library.repository.RentalManageRepository;
 import java.util.Optional;
 
 /**
@@ -72,7 +71,9 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto) {
+    public String add(@RequestParam("stockId") String stockIds,
+            @RequestParam("expectedRentalOn") @DateTimeFormat(pattern = "yyyy-MM-dd") Date specifiedDate, Model model) {
+
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
 
@@ -81,7 +82,20 @@ public class RentalManageController {
         model.addAttribute("accounts", accounts);
 
         if (!model.containsAttribute("rentalManageDto")) {
-            model.addAttribute("rentalManageDto", new RentalManageDto());
+
+            RentalManageDto rentalManageDto = new RentalManageDto();
+            // データセット するかしないか
+            if (stockIds != null) {
+                // 在庫管理番号をセット
+                rentalManageDto.setStockId(stockIds);
+            }
+            if (specifiedDate != null) {
+                // 貸出予定日をセット
+                rentalManageDto.setExpectedRentalOn(specifiedDate);
+            }
+
+            model.addAttribute("rentalManageDto", rentalManageDto);
+
         }
 
         return "rental/add";
@@ -89,9 +103,23 @@ public class RentalManageController {
 
     @PostMapping("/rental/add")
     public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result,
-            RedirectAttributes ra, Model model) {
+            RedirectAttributes ra) {
         // バリデーションチェック
         try {
+            // 日付Format
+            String formatError = rentalManageDto.validDateFormat(rentalManageDto);
+            if (formatError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", formatError));
+                throw new RuntimeException(formatError);
+            }
+
+            // 貸出予定日＜返却予定日
+            String orderDateError = rentalManageDto.orderRentalDate(rentalManageDto);
+            if (orderDateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", orderDateError));
+                throw new RuntimeException(orderDateError);
+            }
+
             // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
             String stockId = rentalManageDto.getStockId();
             Integer status = rentalManageDto.getStatus();
@@ -105,15 +133,15 @@ public class RentalManageController {
 
                     if (!(stockaddcount == rentaladdcount)) {
                         String rentaladdError = "この期間は貸出できません。";
-                        result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentaladdError));
-                        result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentaladdError));
+                        result.addError(new FieldError("rentalManageDto", "expectedRentalOn", rentaladdError));
+                        result.addError(new FieldError("rentalManageDto", "expectedReturnOn", rentaladdError));
                     }
                 }
             }
-
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
+
             // 登録処理
             this.rentalManageService.save(rentalManageDto);
 
@@ -121,23 +149,11 @@ public class RentalManageController {
         } catch (Exception e) {
             log.error(e.getMessage());
 
-            rentalManageDto.setEmployeeId(rentalManageDto.getEmployeeId());
-            rentalManageDto.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
-            rentalManageDto.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
-            rentalManageDto.setStatus(rentalManageDto.getStatus());
-            rentalManageDto.setStockId(rentalManageDto.getStockId());
-
-            List<Stock> stockList = this.stockService.findAll();
-            List<Account> accounts = this.accountService.findAll();
-
-            model.addAttribute("rentalStatus", RentalStatus.values());
-            model.addAttribute("stockList", stockList);
-            model.addAttribute("accounts", accounts);
-
             ra.addFlashAttribute("rentalManageDto", rentalManageDto);
             ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
 
-            return "/rental/add";
+            return "redirect:/rental/add";
+
         }
     }
 
@@ -179,9 +195,23 @@ public class RentalManageController {
         try {
             // 変更前の貸出情報を取得
             RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
-            // 変更前と変更後の貸出ステータスを取得
-            Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
+
+            // 日付Format
+            String formatError = rentalManageDto.validDateFormat(rentalManageDto);
+            if (formatError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", formatError));
+                throw new RuntimeException(formatError);
+            }
+
+            // 貸出予定日＜返却予定日
+            String orderDateError = rentalManageDto.orderRentalDate(rentalManageDto);
+            if (orderDateError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", orderDateError));
+                throw new RuntimeException(orderDateError);
+            }
+
             // Optionalが空でない場合のみエラーを処理する
+            Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
             validErrorOptional.ifPresent(validError -> {
                 if (!validError.isEmpty()) {
                     result.addError(new FieldError("rentalmanageDto", "status", validError));
@@ -189,18 +219,28 @@ public class RentalManageController {
                 }
             });
 
+            // ステータスと日付チェック
+            String DateError = rentalManageDto.isDateError(rentalManage, rentalManageDto);
+            if (DateError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", DateError));
+                throw new RuntimeException(DateError);
+            }
+
             // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
             String stockId = rentalManageDto.getStockId();
-            Long ID = rentalManage.getId();
+            Long rentalId = rentalManage.getId();
             Integer status = rentalManageDto.getStatus();
 
-            if (status == 0 || status == 1) {
-                Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId, ID);
+            if (status == RentalStatus.RENT_WAIT.getValue() || status == RentalStatus.RENTALING.getValue()) {
+                Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId, rentalId);
 
                 if (!(stockcount == 0)) {
+
                     Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
                     Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
-                    Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId, ID,
+
+                    Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId,
+                            rentalId,
                             expectedReturnOn, expectedRentalOn);
 
                     if (!(stockcount == rentalcount)) {
@@ -220,7 +260,9 @@ public class RentalManageController {
 
             return "redirect:/rental/index";
 
-        } catch (Exception e) {
+        } catch (
+
+        Exception e) {
             log.error(e.getMessage());
 
             // 変更前の貸出情報を取得

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,7 +1,8 @@
 package jp.co.metateam.library.controller;
+
 import java.util.List;
 import java.util.Date;
- 
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,7 +12,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
- 
+
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.RentalManage;
@@ -28,235 +29,215 @@ import org.springframework.web.bind.annotation.PathVariable;
 import jp.co.metateam.library.constants.Constants;
 import jp.co.metateam.library.repository.RentalManageRepository;
 import java.util.Optional;
- 
- 
+
 /**
  * 貸出管理関連クラスß
  */
 @Log4j2
 @Controller
 public class RentalManageController {
- 
+
     private final BookMstService bookMstService;
     private final StockService stockService;
     private final AccountService accountService;
     private final RentalManageService rentalManageService;
- 
+
     @Autowired
     public RentalManageController(
-        AccountService accountService,
-        RentalManageService rentalManageService,
-        StockService stockService,
-        BookMstService bookMstService
-    ) {
+            AccountService accountService,
+            RentalManageService rentalManageService,
+            StockService stockService,
+            BookMstService bookMstService) {
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
         this.bookMstService = bookMstService;
     }
- 
+
     /**
      * 貸出一覧画面初期表示
+     * 
      * @param model
      * @return
      */
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-            List<RentalManage> rentalManageList = this.rentalManageService.findAll();
-        // 貸出一覧画面に渡すデータをmodelに追加    
-            model.addAttribute("rentalManageList", rentalManageList);
- 
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
+        // 貸出一覧画面に渡すデータをmodelに追加
+        model.addAttribute("rentalManageList", rentalManageList);
+
         // 貸出一覧画面に遷移
-            return "rental/index";
-        }
-   
+        return "rental/index";
+    }
+
     @GetMapping("/rental/add")
     public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto) {
-        List <Stock> stockList = this.stockService.findAll();
-        List <Account> accounts = this.accountService.findAll();
- 
+        List<Stock> stockList = this.stockService.findStockAvailableAll();
+        List<Account> accounts = this.accountService.findAll();
+
         model.addAttribute("rentalStatus", RentalStatus.values());
         model.addAttribute("stockList", stockList);
         model.addAttribute("accounts", accounts);
- 
+
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
- 
+
         return "rental/add";
     }
-   
- 
+
     @PostMapping("/rental/add")
-    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra, Model model){
-        //バリデーションチェック
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result,
+            RedirectAttributes ra, Model model) {
+        // バリデーションチェック
         try {
-                //貸出ステータスのチェック,(rentalmanageDTOでチェック→ここで呼び出す)
-                //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
-                String stockId = rentalManageDto.getStockId();
-                Integer status = rentalManageDto.getStatus();
-                if(status == 0 || status == 1) {
-                    Long stockaddcount = this.rentalManageService.countByStockIdAndStatus(stockId);
-                        if(!(stockaddcount == 0)) {
-                            Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
-                            Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
-                            Long rentaladdcount = this.rentalManageService.countByStockIdAndStatusAndExpectedDates(stockId, expectedReturnOn, expectedRentalOn);
+            // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
+            String stockId = rentalManageDto.getStockId();
+            Integer status = rentalManageDto.getStatus();
+            if (status == 0 || status == 1) {
+                Long stockaddcount = this.rentalManageService.countByStockIdAndStatus(stockId);
+                if (!(stockaddcount == 0)) {
+                    Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+                    Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+                    Long rentaladdcount = this.rentalManageService.countByStockIdAndStatusAndExpectedDates(stockId,
+                            expectedReturnOn, expectedRentalOn);
 
-                            if(!(stockaddcount==rentaladdcount)) {
-                                String rentaladdError = "この期間は貸出できません。";
-                                result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentaladdError));
-                                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentaladdError));
-                            }
-                        }
-                }
-
-                if (result.hasErrors()) {
-                    throw new Exception("Validation error.");
-                }
-                // 登録処理
-                this.rentalManageService.save(rentalManageDto);
-   
-                return "redirect:/rental/index";
-            } catch (Exception e) {
-                log.error(e.getMessage());
-
-                //変更前の貸出情報を取得
-                //RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
- 
-                //rentalManageDto.setId(rentalManageDto.getId());
-                rentalManageDto.setEmployeeId(rentalManageDto.getEmployeeId());
-                rentalManageDto.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
-                rentalManageDto.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
-                rentalManageDto.setStatus(rentalManageDto.getStatus());
-                rentalManageDto.setStockId(rentalManageDto.getStockId());
-
-                List <Stock> stockList = this.stockService.findAll();
-                List <Account> accounts = this.accountService.findAll();
- 
-                model.addAttribute("rentalStatus", RentalStatus.values());
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("accounts", accounts);
- 
-                ra.addFlashAttribute("rentalManageDto", rentalManageDto);
-                ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
-   
-                return "/rental/add";
-            }
-    }
- 
- 
-    @GetMapping("/rental/{id}/edit")
-    public String edit(@PathVariable("id") String id, Model model) {
- 
-        List<Account> accounts = this.accountService.findAll();
-        List <Stock> stockList = this.stockService.findStockAvailableAll();
-       
-        model.addAttribute("accounts",accounts);
-        model.addAttribute("stockList", stockList);
-        model.addAttribute("rentalStatus", RentalStatus.values());
- 
-        if (!model.containsAttribute("rentalManageDto")) {
-           
-         //DBから編集する貸出管理番号のレコードを取得する
-         RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
-         
-         //レコードのデータを挿入する箱を作る
-         RentalManageDto rentalManageDto = new RentalManageDto();
-         //箱にデータを移す
-         rentalManageDto.setId(rentalManage.getId());
-         rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
-         rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
-         rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
-         rentalManageDto.setStatus(rentalManage.getStatus());
-         rentalManageDto.setStockId(rentalManage.getStock().getId());
- 
-         model.addAttribute("rentalManageDto", rentalManageDto);
-        }
- 
-        return "rental/edit";
- 
-    }
- 
-    @PostMapping("/rental/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, Model model,RedirectAttributes ra) {
-        try {
-             // 変更前の貸出情報を取得
-             RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
-             // 変更前と変更後の貸出ステータスを取得
-             Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
-             // Optionalが空でない場合のみエラーを処理する
-              validErrorOptional.ifPresent(validError -> {
-                 if (!validError.isEmpty()) {
-                    result.addError(new FieldError("rentalmanageDto", "status", validError));
-                     throw new RuntimeException(validError);
-                 }
-             });
-
-              //貸出ステータスのチェック,(rentalmanageDTOでチェック→ここで呼び出す)
-             //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
-             String stockId = rentalManageDto.getStockId();
-             Long ID = rentalManage.getId();
-             Integer status = rentalManageDto.getStatus();
-
-             if(status == 0 || status == 1) {
-                    Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId,ID);
-            
-
-                  if(!(stockcount == 0)) {
-                     Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
-                     Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
-                     Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId,ID, expectedReturnOn, expectedRentalOn);
-
-                     if(!(stockcount==rentalcount)) {
-                         String rentalError = "この期間は貸出できません。";
-                         result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentalError));
-                         result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentalError));
-                        }
+                    if (!(stockaddcount == rentaladdcount)) {
+                        String rentaladdError = "この期間は貸出できません。";
+                        result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentaladdError));
+                        result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentaladdError));
                     }
                 }
-            
+            }
 
-             if (result.hasErrors()) {
+            if (result.hasErrors()) {
+                throw new Exception("Validation error.");
+            }
+            // 登録処理
+            this.rentalManageService.save(rentalManageDto);
+
+            return "redirect:/rental/index";
+        } catch (Exception e) {
+            log.error(e.getMessage());
+
+            rentalManageDto.setEmployeeId(rentalManageDto.getEmployeeId());
+            rentalManageDto.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
+            rentalManageDto.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
+            rentalManageDto.setStatus(rentalManageDto.getStatus());
+            rentalManageDto.setStockId(rentalManageDto.getStockId());
+
+            List<Stock> stockList = this.stockService.findAll();
+            List<Account> accounts = this.accountService.findAll();
+
+            model.addAttribute("rentalStatus", RentalStatus.values());
+            model.addAttribute("stockList", stockList);
+            model.addAttribute("accounts", accounts);
+
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+
+            return "/rental/add";
+        }
+    }
+
+    @GetMapping("/rental/{id}/edit")
+    public String edit(@PathVariable("id") String id, Model model) {
+
+        List<Account> accounts = this.accountService.findAll();
+        List<Stock> stockList = this.stockService.findStockAvailableAll();
+
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+
+        if (!model.containsAttribute("rentalManageDto")) {
+
+            // DBから編集する貸出管理番号のレコードを取得する
+            RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+
+            // レコードのデータを挿入する箱を作る
+            RentalManageDto rentalManageDto = new RentalManageDto();
+            // 箱にデータを移す
+            rentalManageDto.setId(rentalManage.getId());
+            rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
+            rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
+            rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
+            rentalManageDto.setStatus(rentalManage.getStatus());
+            rentalManageDto.setStockId(rentalManage.getStock().getId());
+
+            model.addAttribute("rentalManageDto", rentalManageDto);
+        }
+
+        return "rental/edit";
+
+    }
+
+    @PostMapping("/rental/{id}/edit")
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute RentalManageDto rentalManageDto,
+            BindingResult result, Model model, RedirectAttributes ra) {
+        try {
+            // 変更前の貸出情報を取得
+            RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+            // 変更前と変更後の貸出ステータスを取得
+            Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
+            // Optionalが空でない場合のみエラーを処理する
+            validErrorOptional.ifPresent(validError -> {
+                if (!validError.isEmpty()) {
+                    result.addError(new FieldError("rentalmanageDto", "status", validError));
+                    throw new RuntimeException(validError);
+                }
+            });
+
+            // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
+            String stockId = rentalManageDto.getStockId();
+            Long ID = rentalManage.getId();
+            Integer status = rentalManageDto.getStatus();
+
+            if (status == 0 || status == 1) {
+                Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId, ID);
+
+                if (!(stockcount == 0)) {
+                    Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+                    Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+                    Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId, ID,
+                            expectedReturnOn, expectedRentalOn);
+
+                    if (!(stockcount == rentalcount)) {
+                        String rentalError = "この期間は貸出できません。";
+                        result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentalError));
+                        result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentalError));
+                    }
+                }
+            }
+
+            if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
 
-             // 更新処理
-             this.rentalManageService.update(Long.valueOf(id), rentalManageDto);
-           
-             return "redirect:/rental/index";
- 
-            //貸出ステータスのチェック(rentalmanageDTOでチェック→ここで呼び出す)
-            //貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
- 
+            // 更新処理
+            this.rentalManageService.update(Long.valueOf(id), rentalManageDto);
+
+            return "redirect:/rental/index";
+
         } catch (Exception e) {
             log.error(e.getMessage());
-       
-         //変更前の貸出情報を取得
-         RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
- 
-         rentalManageDto.setId(rentalManage.getId());
-         rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
-         rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
-         rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
-         rentalManageDto.setStatus(rentalManage.getStatus());
-         rentalManageDto.setStockId(rentalManage.getStock().getId());
- 
-         ra.addFlashAttribute("rentalManageDto", rentalManageDto);
-         ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
- 
-         /*List<Account> accounts = this.accountService.findAll();
-         List <Stock> stockList = this.stockService.findStockAvailableAll();
-       
-         model.addAttribute("accounts",accounts);
-         model.addAttribute("stockList", stockList);
-         model.addAttribute("rentalStatus", RentalStatus.values());*/
- 
-         //元データを再取得
-          // List <RentalManage> rentalManageList = this.rentalManageRepository.findById();
-         
-           return String.format("redirect:/rental/%s/edit",id);
+
+            // 変更前の貸出情報を取得
+            RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
+
+            rentalManageDto.setId(rentalManage.getId());
+            rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
+            rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
+            rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
+            rentalManageDto.setStatus(rentalManage.getStatus());
+            rentalManageDto.setStockId(rentalManage.getStock().getId());
+
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+
+            return String.format("redirect:/rental/%s/edit", id);
         }
     }
- 
+
 }

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -1,6 +1,8 @@
 package jp.co.metateam.library.controller;
 
 import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
@@ -41,7 +44,7 @@ public class StockController {
 
     @GetMapping("/stock/index")
     public String index(Model model) {
-        List <Stock> stockList = this.stockService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
 
         model.addAttribute("stockList", stockList);
 
@@ -113,7 +116,8 @@ public class StockController {
     }
 
     @PostMapping("/stock/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result, RedirectAttributes ra) {
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result,
+            RedirectAttributes ra) {
         try {
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
@@ -132,23 +136,27 @@ public class StockController {
     }
 
     @GetMapping("/stock/calendar")
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
+            Model model) {
 
         LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
+        // 表示する年月を取得
         Integer targetYear = year == null ? today.getYear() : year;
+        // カレンダーの表示範囲の開始日を計算
         Integer targetMonth = today.getMonthValue();
 
+        // 表示される月の日数を計算
         LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
         Integer daysInMonth = startDate.lengthOfMonth();
 
+        // カレンダーの曜日と在庫データを生成
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<List<CalendarDto>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
-
         model.addAttribute("stocks", stocks);
 
         return "stock/calendar";

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -124,7 +124,6 @@ public class StockController {
             return "stock/index";
         } catch (Exception e) {
             log.error(e.getMessage());
-
             ra.addFlashAttribute("stockDto", stockDto);
             ra.addFlashAttribute("org.springframework.validation.BindingResult.stockDto", result);
 

--- a/src/main/java/jp/co/metateam/library/model/BookMstDto.java
+++ b/src/main/java/jp/co/metateam/library/model/BookMstDto.java
@@ -2,8 +2,6 @@ package jp.co.metateam.library.model;
 
 import java.security.Timestamp;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,15 +11,15 @@ import lombok.Setter;
 @Getter
 @Setter
 public class BookMstDto {
-    
-    private Long id; 
-    
+
+    private Long id;
+
     private String isbn;
 
     private String title;
-    
+
     private long stockCount;
-    
+
     private Timestamp deletedAt;
 
     private BookMst bookMst;

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -2,6 +2,7 @@ package jp.co.metateam.library.model;
 
 import java.util.Date;
 import java.sql.Timestamp;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -95,7 +95,7 @@ public class RentalManage {
     public Account getAccount() {
         return account;
     }
-    
+
     /** Setters */
 
     public void setId(Long id) {

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -2,7 +2,6 @@ package jp.co.metateam.library.model;
 
 import java.util.Date;
 import java.sql.Timestamp;
-import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -3,6 +3,9 @@ package jp.co.metateam.library.model;
 import jp.co.metateam.library.values.RentalStatus;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 
@@ -63,6 +66,61 @@ public class RentalManageDto {
         }
         return Optional.empty();
 
+    }
+
+    // 日付チェック
+    public String isDateError(RentalManage rentalManage, RentalManageDto rentalManageDto) {
+        // 現在の日時
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo"));
+
+        // status 古いのと新しいの
+        Integer prestatus = rentalManage.getStatus();
+        Integer poststatus = rentalManageDto.getStatus();
+
+        // expectedを二つ
+        LocalDate expectedRentalOn = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+        LocalDate expectedReturnOn = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+
+        // if文・貸出待ち→貸出中、・貸出中→返却済み
+        if (prestatus == 0 && poststatus == 1) {
+            if (!expectedRentalOn.equals(nowDate)) {
+                return "貸出予定日は現在の日付を選択してください。";
+            }
+        }
+
+        if (prestatus == 1 && poststatus == 2) {
+            if (!expectedReturnOn.equals(nowDate)) {
+                return "返却予定日は現在の日付を選択してください。";
+            }
+        }
+        return null;
+    }
+
+    // 貸出予定日＜返却予定日
+    public String orderRentalDate(RentalManageDto rentalManageDto) {
+        Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+        Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+
+        if (!expectedRentalOn.before(expectedReturnOn)) {
+            return "返却予定日は貸出予定日より後の日付を入力してください.";
+        }
+        return null;
+    }
+
+    // 日付Format
+    public String validDateFormat(RentalManageDto rentalManageDto) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+
+        String expectedRentalOnStr = sdf.format(rentalManageDto.getExpectedRentalOn());
+        String expectedReturnOnStr = sdf.format(rentalManageDto.getExpectedReturnOn());
+
+        if (!expectedRentalOnStr.matches("\\d{4}/\\d{2}/\\d{2}")
+                || !expectedReturnOnStr.matches("\\d{4}/\\d{2}/\\d{2}")) {
+            return "yyyy/mm/ddのフォーマットで入力してください";
+        }
+        return null;
     }
 
 }

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,6 +1,6 @@
 package jp.co.metateam.library.model;
-import jp.co.metateam.library.values.RentalStatus;
 
+import jp.co.metateam.library.values.RentalStatus;
 
 import java.sql.Timestamp;
 import java.util.Date;
@@ -22,21 +22,21 @@ public class RentalManageDto {
 
     private Long id;
 
-    @NotEmpty(message="在庫管理番号は必須です")
+    @NotEmpty(message = "在庫管理番号は必須です")
     private String stockId;
 
-    @NotEmpty(message="社員番号は必須です")
+    @NotEmpty(message = "社員番号は必須です")
     private String employeeId;
 
-    @NotNull(message="貸出ステータスは必須です")
+    @NotNull(message = "貸出ステータスは必須です")
     private Integer status;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="貸出予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "貸出予定日は必須です")
     private Date expectedRentalOn;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="返却予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "返却予定日は必須です")
     private Date expectedReturnOn;
 
     private Timestamp rentaledAt;
@@ -49,7 +49,6 @@ public class RentalManageDto {
 
     private Account account;
 
-
     public Optional<String> isStatusError(Integer preStatus) {
         if (preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
             return Optional.of("「貸出待ち」から「返却済み」は選択できません");
@@ -61,31 +60,9 @@ public class RentalManageDto {
             return Optional.of("「返却済み」から変更はできません");
         } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status != RentalStatus.CANCELED.getValue()) {
             return Optional.of("「キャンセル」から変更はできません");
-        } 
-            return Optional.empty();
-        
-    }
-    
-    
-}
+        }
+        return Optional.empty();
 
-/* if (preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
-            return Optional.of("「貸出待ち」から「返却済み」は選択できません");
-        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
-            return Optional.of("「貸出中」から「貸出待ち」には変更できません");
-        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
-            return Optional.of("「貸出中」から「キャンセル」には変更できません");
-        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status != RentalStatus.RENT_WAIT.getValue()) {
-            return Optional.of("「返却済み」から「貸出待ち」には変更できません");
-        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENTALING.getValue()) {
-            return Optional.of("「返却済み」から「貸出中」には変更できません");
-        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
-            return Optional.of("「返却済み」から「キャンセル」には変更できません");
-        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
-            return Optional.of("「キャンセル」から「貸出待ち」には変更できません");
-        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENTALING.getValue()) {
-            return Optional.of("「キャンセル」から「貸出中」には変更できません");
-        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
-            return Optional.of("「キャンセル」から「返却済み」には変更できません");
-        } 
-            return Optional.empty(); */
+    }
+
+}

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,7 +1,10 @@
 package jp.co.metateam.library.model;
+import jp.co.metateam.library.values.RentalStatus;
+
 
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.Optional;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -45,4 +48,44 @@ public class RentalManageDto {
     private Stock stock;
 
     private Account account;
+
+
+    public Optional<String> isStatusError(Integer preStatus) {
+        if (preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
+            return Optional.of("「貸出待ち」から「返却済み」は選択できません");
+        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return Optional.of("「貸出中」から「貸出待ち」には変更できません");
+        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
+            return Optional.of("「貸出中」から「キャンセル」には変更できません");
+        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status != RentalStatus.RETURNED.getValue()) {
+            return Optional.of("「返却済み」から変更はできません");
+        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status != RentalStatus.CANCELED.getValue()) {
+            return Optional.of("「キャンセル」から変更はできません");
+        } 
+            return Optional.empty();
+        
+    }
+    
+    
 }
+
+/* if (preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
+            return Optional.of("「貸出待ち」から「返却済み」は選択できません");
+        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return Optional.of("「貸出中」から「貸出待ち」には変更できません");
+        } else if (preStatus == RentalStatus.RENTALING.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
+            return Optional.of("「貸出中」から「キャンセル」には変更できません");
+        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status != RentalStatus.RENT_WAIT.getValue()) {
+            return Optional.of("「返却済み」から「貸出待ち」には変更できません");
+        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENTALING.getValue()) {
+            return Optional.of("「返却済み」から「貸出中」には変更できません");
+        } else if (preStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
+            return Optional.of("「返却済み」から「キャンセル」には変更できません");
+        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return Optional.of("「キャンセル」から「貸出待ち」には変更できません");
+        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENTALING.getValue()) {
+            return Optional.of("「キャンセル」から「貸出中」には変更できません");
+        } else if (preStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
+            return Optional.of("「キャンセル」から「返却済み」には変更できません");
+        } 
+            return Optional.empty(); */

--- a/src/main/java/jp/co/metateam/library/model/calendarDto.java
+++ b/src/main/java/jp/co/metateam/library/model/calendarDto.java
@@ -1,0 +1,25 @@
+package jp.co.metateam.library.model;
+
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 在庫管理DTO
+ */
+@Getter
+@Setter
+public class CalendarDto {
+
+    private String title;
+
+    private String stockId;
+
+    private Date expectedRentalOn;
+
+    private Long countAvailableRental;
+
+    private Long stockCount;
+
+}

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -1,11 +1,13 @@
 package jp.co.metateam.library.repository;
-
+ 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-
+ 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
+ 
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
@@ -13,4 +15,38 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
     List<RentalManage> findAll();
 
 	Optional<RentalManage> findById(Long id);
+
+@Query //登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+("SELECT COUNT(rm) FROM RentalManage rm " +
+" WHERE rm.stock.id = ?1 " +
+" AND rm.status IN (0, 1) " )
+long countByStockIdAndStatus(String stockId);
+    
+    
+@Query //登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+("SELECT COUNT(rm) FROM RentalManage rm " +
+" WHERE rm.stock.id = ?1 " +
+" AND rm.status IN (0, 1) " +
+" AND rm.expectedReturnOn < ?2 " +
+" AND rm.expectedRentalOn > ?3" )
+long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn);
+    
+
+
+@Query //変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+("SELECT COUNT(rm) FROM RentalManage rm " +
+" WHERE rm.stock.id = ?1 " +
+" AND rm.status IN (0, 1) " +
+" AND rm.id != ?2 ")
+long countByStockIdAndStatusIn(String stockId, Long ID);
+
+
+@Query //変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+("SELECT COUNT(rm) FROM RentalManage rm " +
+" WHERE rm.stock.id = ?1 " +
+" AND rm.status IN (0, 1) " +
+" AND rm.id != ?2 " +
+" AND rm.expectedReturnOn < ?3 " +
+" OR rm.expectedRentalOn > ?4" )
+long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn, Date expectedReturnOn);
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -7,43 +7,41 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
-    List<RentalManage> findAll();
+        List<RentalManage> findAll();
 
-    Optional<RentalManage> findById(Long id);
+        Optional<RentalManage> findById(Long id);
 
-    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) ")
-    long countByStockIdAndStatus(String stockId);
+        @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1  AND rm.status IN (0, 1) ")
+        long countByStockIdAndStatus(String stockId);
 
-    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.expectedReturnOn < ?2 " +
-            " AND rm.expectedRentalOn > ?3")
-    long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn);
+        @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.expectedReturnOn < ?2  AND rm.expectedRentalOn > ?3")
+        long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedRentalOn, Date expectedReturnOn);
 
-    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.id != ?2 ")
-    long countByStockIdAndStatusIn(String stockId, Long ID);
+        @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1)  AND rm.id != ?2 ")
+        long countByStockIdAndStatusIn(String stockId, Long ID);
 
-    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.id != ?2 " +
-            " AND rm.expectedReturnOn < ?3 " +
-            " OR rm.expectedRentalOn > ?4")
-    long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
-            Date expectedReturnOn);
+        @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.id != ?2 AND rm.expectedReturnOn < ?3  OR rm.expectedRentalOn > ?4")
+        long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
+                        Date expectedReturnOn);
+
+        @Query // タイトル別、日ごとの貸し出されている冊数
+        (value = "SELECT COUNT(*) FROM rental_manage rm INNER JOIN stocks s ON rm.stock_id = s.id INNER JOIN book_mst bm ON s.book_id = bm.id "
+                        +
+                        " WHERE bm.title = ?1 AND (rm.expected_rental_on <= ?2 AND rm.expected_return_on >= ?2)", nativeQuery = true)
+        Long countBySpecifiedDateRentals(String title, Date specifiedDate);
+
+        // タイトル、在庫管理番号
+        @Query(value = "SELECT s.id FROM stocks s Left JOIN rental_manage rm  ON s.id = rm.stock_id JOIN book_mst bm ON s.book_id = bm.id WHERE s.status = 0 AND bm.title= :title AND (rm.stock_id is null OR rm.expected_rental_on > :day OR rm.expected_return_on < :day OR rm.status = 3)", nativeQuery = true)
+        List<String> selectByStockId(@Param("title") String title, @Param("day") Date specifiedDate);
+
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -1,52 +1,49 @@
 package jp.co.metateam.library.repository;
- 
+
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
- 
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
- 
+
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
     List<RentalManage> findAll();
 
-	Optional<RentalManage> findById(Long id);
+    Optional<RentalManage> findById(Long id);
 
-@Query //登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-("SELECT COUNT(rm) FROM RentalManage rm " +
-" WHERE rm.stock.id = ?1 " +
-" AND rm.status IN (0, 1) " )
-long countByStockIdAndStatus(String stockId);
-    
-    
-@Query //登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-("SELECT COUNT(rm) FROM RentalManage rm " +
-" WHERE rm.stock.id = ?1 " +
-" AND rm.status IN (0, 1) " +
-" AND rm.expectedReturnOn < ?2 " +
-" AND rm.expectedRentalOn > ?3" )
-long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn);
-    
+    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+    ("SELECT COUNT(rm) FROM RentalManage rm " +
+            " WHERE rm.stock.id = ?1 " +
+            " AND rm.status IN (0, 1) ")
+    long countByStockIdAndStatus(String stockId);
 
+    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+    ("SELECT COUNT(rm) FROM RentalManage rm " +
+            " WHERE rm.stock.id = ?1 " +
+            " AND rm.status IN (0, 1) " +
+            " AND rm.expectedReturnOn < ?2 " +
+            " AND rm.expectedRentalOn > ?3")
+    long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn);
 
-@Query //変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-("SELECT COUNT(rm) FROM RentalManage rm " +
-" WHERE rm.stock.id = ?1 " +
-" AND rm.status IN (0, 1) " +
-" AND rm.id != ?2 ")
-long countByStockIdAndStatusIn(String stockId, Long ID);
+    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+    ("SELECT COUNT(rm) FROM RentalManage rm " +
+            " WHERE rm.stock.id = ?1 " +
+            " AND rm.status IN (0, 1) " +
+            " AND rm.id != ?2 ")
+    long countByStockIdAndStatusIn(String stockId, Long ID);
 
-
-@Query //変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-("SELECT COUNT(rm) FROM RentalManage rm " +
-" WHERE rm.stock.id = ?1 " +
-" AND rm.status IN (0, 1) " +
-" AND rm.id != ?2 " +
-" AND rm.expectedReturnOn < ?3 " +
-" OR rm.expectedRentalOn > ?4" )
-long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn, Date expectedReturnOn);
+    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+    ("SELECT COUNT(rm) FROM RentalManage rm " +
+            " WHERE rm.stock.id = ?1 " +
+            " AND rm.status IN (0, 1) " +
+            " AND rm.id != ?2 " +
+            " AND rm.expectedReturnOn < ?3 " +
+            " OR rm.expectedRentalOn > ?4")
+    long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
+            Date expectedReturnOn);
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -4,20 +4,26 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
-    
+
     List<Stock> findAll();
 
     List<Stock> findByDeletedAtIsNull();
 
     List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
 
-	Optional<Stock> findById(String id);
-    
-    List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+    Optional<Stock> findById(String id);
+
+    List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
+
+    // タイトル、在庫数
+    @Query("SELECT s.bookMst.title, COUNT(s) FROM Stock s JOIN s.bookMst WHERE s.status = 0 GROUP BY s.bookMst.title")
+    List<Object[]> countByTotalStockPerTitle();
+
 }

--- a/src/main/java/jp/co/metateam/library/service/AccountService.java
+++ b/src/main/java/jp/co/metateam/library/service/AccountService.java
@@ -47,6 +47,8 @@ public class AccountService implements UserDetailsService {
         return this.accountRepository.findAll();
     }
 
+
+
     @Transactional
     public void save(AccountDto accountDto) {
         try {

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import io.micrometer.common.util.StringUtils;
 import jp.co.metateam.library.constants.Constants;
@@ -23,9 +22,9 @@ public class BookMstService {
 
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
-    
+
     @Autowired
-    public BookMstService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public BookMstService(BookMstRepository bookMstRepository, StockRepository stockRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
     }
@@ -37,7 +36,7 @@ public class BookMstService {
     public Optional<BookMst> findById(Long id) {
         return this.bookMstRepository.findById(id);
     }
-    
+
     public List<BookMstDto> findAvailableWithStockCount() {
         List<BookMst> books = this.bookMstRepository.findAll();
         List<BookMstDto> bookMstDtoList = new ArrayList<BookMstDto>();
@@ -46,7 +45,8 @@ public class BookMstService {
         // FIXME: 現状は書籍ID毎にDBに問い合わせている。一度のSQLで完了させたい。
         for (int i = 0; i < books.size(); i++) {
             BookMst book = books.get(i);
-            List<Stock> stockCount = this.stockRepository.findByBookMstIdAndStatus(book.getId(), Constants.STOCK_AVAILABLE);
+            List<Stock> stockCount = this.stockRepository.findByBookMstIdAndStatus(book.getId(),
+                    Constants.STOCK_AVAILABLE);
             BookMstDto bookMstDto = new BookMstDto();
             bookMstDto.setId(book.getId());
             bookMstDto.setIsbn(book.getIsbn());
@@ -57,7 +57,7 @@ public class BookMstService {
 
         return bookMstDtoList;
     }
-    
+
     @Transactional
     public void save(BookMstDto bookMstDto) {
         try {
@@ -72,8 +72,6 @@ public class BookMstService {
             throw e;
         }
     }
-    
-   
 
     @Transactional
     public void update(Long id, BookMstDto bookMstDto) throws Exception {
@@ -109,23 +107,4 @@ public class BookMstService {
         }
         return false;
     }
-
-    // public boolean isValidTitle(String title, RedirectAttributes ra) {
-    //     if (StringUtils.isEmpty(title)) {
-    //         ra.addFlashAttribute("errTitle", "書籍タイトルは必須");
-    //         return true;
-    //     }
-    //     return false;
-    // }
-
-    // public boolean isValidIsbn(String isbn, RedirectAttributes ra) {
-    //     if (StringUtils.isEmpty(isbn) || isbn.length() != 13) {
-    //         ra.addFlashAttribute("errISBN", "ISBNは13文字で入力してください");
-    //         return true;
-    //     }
-    //     return false;
-    // }
 }
-
-
-

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -73,6 +73,8 @@ public class BookMstService {
         }
     }
     
+   
+
     @Transactional
     public void update(Long id, BookMstDto bookMstDto) throws Exception {
         try {

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -112,6 +112,9 @@ public class RentalManageService {
         return rentalManage;
     }
 
+    // 現在日時取得
+    Date date = new Date();
+
     @Transactional
     public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
         try {

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -1,10 +1,8 @@
 package jp.co.metateam.library.service;
 
-
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Date;
-
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,20 +24,19 @@ public class RentalManageService {
     private final RentalManageRepository rentalManageRepository;
     private final StockRepository stockRepository;
 
-     @Autowired
+    @Autowired
     public RentalManageService(
-        AccountRepository accountRepository,
-        RentalManageRepository rentalManageRepository,
-        StockRepository stockRepository
-    ) {
+            AccountRepository accountRepository,
+            RentalManageRepository rentalManageRepository,
+            StockRepository stockRepository) {
         this.accountRepository = accountRepository;
         this.rentalManageRepository = rentalManageRepository;
         this.stockRepository = stockRepository;
     }
 
     @Transactional
-    public List <RentalManage> findAll() {
-        List <RentalManage> rentalManageList = this.rentalManageRepository.findAll();
+    public List<RentalManage> findAll() {
+        List<RentalManage> rentalManageList = this.rentalManageRepository.findAll();
 
         return rentalManageList;
     }
@@ -49,31 +46,30 @@ public class RentalManageService {
         return this.rentalManageRepository.findById(id).orElse(null);
     }
 
-
-    @Transactional //登録の予約数
+    @Transactional // 登録の予約数
     public Long countByStockIdAndStatus(String stockId) {
         return this.rentalManageRepository.countByStockIdAndStatus(stockId);
     }
 
-    @Transactional //登録の期間被ってない本の数SQL
+    @Transactional // 登録の期間被ってない本の数SQL
     public Long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn) {
-        return this.rentalManageRepository.countByStockIdAndStatusAndExpectedDates(stockId, expectedReturnOn, expectedRentalOn);
+        return this.rentalManageRepository.countByStockIdAndStatusAndExpectedDates(stockId, expectedReturnOn,
+                expectedRentalOn);
     }
 
-    @Transactional//編集の予約数
+    @Transactional // 編集の予約数
     public Long countByStockIdAndStatusIn(String stockId, Long ID) {
         return this.rentalManageRepository.countByStockIdAndStatusIn(stockId, ID);
     }
 
-    @Transactional//編集の期間被ってない本の数SQL
-    public Long countByStockIdAndStatusInAndExpectedDates(String stockId, Long id, Date expectedReturnOn, Date expectedRentalOn) {
-        return this.rentalManageRepository.countByStockIdAndStatusInAndExpectedDates(stockId, id, expectedReturnOn, expectedRentalOn);
+    @Transactional // 編集の期間被ってない本の数SQL
+    public Long countByStockIdAndStatusInAndExpectedDates(String stockId, Long id, Date expectedReturnOn,
+            Date expectedRentalOn) {
+        return this.rentalManageRepository.countByStockIdAndStatusInAndExpectedDates(stockId, id, expectedReturnOn,
+                expectedRentalOn);
     }
 
-    
-    
-
-    @Transactional 
+    @Transactional
     public void save(RentalManageDto rentalManageDto) throws Exception {
         try {
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
@@ -104,7 +100,7 @@ public class RentalManageService {
 
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        
+
         if (status == RentalStatus.RENTALING.getValue()) {
             rentalManage.setRentaledAt(timestamp);
         } else if (status == RentalStatus.RETURNED.getValue()) {
@@ -124,25 +120,24 @@ public class RentalManageService {
             if (updateTargetRental == null) {
                 throw new Exception("RentalManage record not found.");
             }
- 
+
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
             if (account == null) {
                 throw new Exception("Account not found.");
             }
- 
+
             Stock stock = this.stockRepository.findById(rentalManageDto.getStockId()).orElse(null);
             if (stock == null) {
                 throw new Exception("Stock not found.");
             }
- 
- 
+
             updateTargetRental.setId(rentalManageDto.getId());
             updateTargetRental.setAccount(account);
             updateTargetRental.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
             updateTargetRental.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
             updateTargetRental.setStatus(rentalManageDto.getStatus());
             updateTargetRental.setStock(stock);
- 
+
             // データベースへの保存
             this.rentalManageRepository.save(updateTargetRental);
         } catch (Exception e) {
@@ -150,5 +145,3 @@ public class RentalManageService {
         }
     }
 }
-
-//* manageserviceで結果をチェック

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -1,7 +1,10 @@
 package jp.co.metateam.library.service;
 
+
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Date;
+
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -46,6 +49,30 @@ public class RentalManageService {
         return this.rentalManageRepository.findById(id).orElse(null);
     }
 
+
+    @Transactional //登録の予約数
+    public Long countByStockIdAndStatus(String stockId) {
+        return this.rentalManageRepository.countByStockIdAndStatus(stockId);
+    }
+
+    @Transactional //登録の期間被ってない本の数SQL
+    public Long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn) {
+        return this.rentalManageRepository.countByStockIdAndStatusAndExpectedDates(stockId, expectedReturnOn, expectedRentalOn);
+    }
+
+    @Transactional//編集の予約数
+    public Long countByStockIdAndStatusIn(String stockId, Long ID) {
+        return this.rentalManageRepository.countByStockIdAndStatusIn(stockId, ID);
+    }
+
+    @Transactional//編集の期間被ってない本の数SQL
+    public Long countByStockIdAndStatusInAndExpectedDates(String stockId, Long id, Date expectedReturnOn, Date expectedRentalOn) {
+        return this.rentalManageRepository.countByStockIdAndStatusInAndExpectedDates(stockId, id, expectedReturnOn, expectedRentalOn);
+    }
+
+    
+    
+
     @Transactional 
     public void save(RentalManageDto rentalManageDto) throws Exception {
         try {
@@ -78,7 +105,7 @@ public class RentalManageService {
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
         
-        if (status == RentalStatus.RENTAlING.getValue()) {
+        if (status == RentalStatus.RENTALING.getValue()) {
             rentalManage.setRentaledAt(timestamp);
         } else if (status == RentalStatus.RETURNED.getValue()) {
             rentalManage.setReturnedAt(timestamp);
@@ -88,4 +115,40 @@ public class RentalManageService {
 
         return rentalManage;
     }
+
+    @Transactional
+    public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
+        try {
+            // 既存レコード取得
+            RentalManage updateTargetRental = this.rentalManageRepository.findById(id).orElse(null);
+            if (updateTargetRental == null) {
+                throw new Exception("RentalManage record not found.");
+            }
+ 
+            Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
+            if (account == null) {
+                throw new Exception("Account not found.");
+            }
+ 
+            Stock stock = this.stockRepository.findById(rentalManageDto.getStockId()).orElse(null);
+            if (stock == null) {
+                throw new Exception("Stock not found.");
+            }
+ 
+ 
+            updateTargetRental.setId(rentalManageDto.getId());
+            updateTargetRental.setAccount(account);
+            updateTargetRental.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
+            updateTargetRental.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
+            updateTargetRental.setStatus(rentalManageDto.getStatus());
+            updateTargetRental.setStock(stock);
+ 
+            // データベースへの保存
+            this.rentalManageRepository.save(updateTargetRental);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
 }
+
+//* manageserviceで結果をチェック

--- a/src/main/java/jp/co/metateam/library/values/RentalStatus.java
+++ b/src/main/java/jp/co/metateam/library/values/RentalStatus.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RentalStatus implements Values {
     RENT_WAIT(0, "貸出待ち")
-    , RENTAlING(1, "貸出中")
+    , RENTALING(1, "貸出中")
     , RETURNED(2, "返却済み")
     , CANCELED(3, "キャンセル");
 

--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -9,6 +9,7 @@
     max-width: 1200px;
     overflow: scroll;
 }
+
 #calendar_table {
     width: 100%;
     border-collapse: collapse;
@@ -34,4 +35,12 @@
 #calendar_table tr.days th {
     padding: 5px;
     font-size: 14px;
+}
+
+.saturday {
+    color: blue;
+}
+
+.sunday {
+    color: red;
 }

--- a/src/main/resources/static/js/rental/add.js
+++ b/src/main/resources/static/js/rental/add.js
@@ -1,29 +1,29 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedReturnOn").attr("min", date);
 }
 
 
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    //setExpectedRentalOn();
+    //setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {

--- a/src/main/resources/static/js/rental/edit.js
+++ b/src/main/resources/static/js/rental/edit.js
@@ -1,34 +1,34 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedReturnOn").attr("min", date);
 }
 
 
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    //setExpectedRentalOn();
+    //setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {
-            // setExpectedRentalOn();
-            // setExpectedReturnOn();
+            //setExpectedRentalOn();
+            //setExpectedReturnOn();
         } else {
             $("#expectedReturnOn").attr("min", $(this).val());
         }

--- a/src/main/resources/templates/common.html
+++ b/src/main/resources/templates/common.html
@@ -57,6 +57,17 @@
                     <a class="menu_link" th:href="@{/stock/add}">在庫登録</a>
                 </div>
             </details>
+            <div class="menu_item">
+                <a class="menu_link" th:href="@{/stock/calendar}"><img th:src="@{/images/icons/calendar.png}" alt="calendar"/>在庫カレンダー</a>
+            </div>
+            <details class="menu_inner">
+                <summary class="menu_item">
+                    <a class="menu_link" th:href="@{/rental/index}"><img th:src="@{/images/icons/rental.png}" alt="book" />貸出一覧</a>
+                </summary>
+                <div class="menu_item second">
+                    <a class="menu_link" th:href="@{/rental/add}">貸出登録</a>
+                </div>
+            </details>
         </div>
     </div>
 

--- a/src/main/resources/templates/rental/add.html
+++ b/src/main/resources/templates/rental/add.html
@@ -20,7 +20,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post"
+                    novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
+    <title th:text="${title}+' | MTLibrary'"></title>
+    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+</head>
+
+<body>
+    <div class="contents">
+        <div th:replace="~{common :: main_sidebar}"></div>
+        <div class="main_contents">
+            <div th:replace="~{common :: header}"></div>
+            <div class="inner_contens">
+                <div class="page_title">貸出編集</div>
+                <div class="mb30 flexarea">
+                    <span class="text-red">＊は必須項目です</span>
+                    <span>
+                        <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
+                    </span>
+                </div>
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+                    <div class="mb30">
+                        <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
+                        <select id="employeeId" class="form_input" name="employeeId" required>
+                            <option value="">社員番号を選択</option>
+                            <option th:each="account : ${accounts}" th:value="${account.employeeId}"
+                                th:text="${account.employeeId + ' ' + account.name}"
+                                th:selected="${account.employeeId == rentalManageDto.employeeId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('employeeId')}" th:errors="*{employeeId}">
+                        </div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedRentalOn">貸出予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
+                            th:value="${#dates.format(rentalManageDto.expectedRentalOn, ('yyyy-MM-dd'))}"
+                            placeholder="貸出予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
+                            th:errors="*{expectedRentalOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedReturnOn">返却予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedReturnOn" class="form_input" name="expectedReturnOn"
+                            th:value="${#dates.format(rentalManageDto.expectedReturnOn, ('yyyy-MM-dd'))}"
+                            placeholder="返却予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedReturnOn')}"
+                            th:errors="*{expectedReturnOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="stockMngNumber">在庫管理番号<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="stockMngNumber" class="form_input" name="stockId" required>
+                            <option value="">在庫管理番号を選択</option>
+                            <option th:each="stock : ${stockList}" th:value="${stock.id}"
+                                th:text="${stock.id + ' ' + stock.bookMst.title}"
+                                th:selected="${stock.id == rentalManageDto.stockId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('stockId')}" th:errors="*{stockId}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="rentalStatus">貸出ステータス<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="rentalStatus" class="form_input" name="status" required>
+                            <option value="">ステータスを選択</option>
+                            <option th:each="status : ${rentalStatus}" th:value="${status.value}"
+                                th:text="${status.text}" th:selected="${status.value == rentalManageDto.status}">
+                            </option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></div>
+                    </div>
+                    <div class="btn_block">
+                        <button type="submit" id="submit_btn">変更</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div th:replace="~{common :: footer}"></div>
+</body>

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -3,8 +3,8 @@
 
 <head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
-    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
-    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+    <link rel="stylesheet" th:href="@{/css/rental/edit.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/edit.js}"></script>
 </head>
 
 <body>
@@ -20,7 +20,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}"
+                    method="post" novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -29,16 +31,26 @@
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
-                            </tr>
+                                <th class="header_days" th:colspan="${daysInMonth}"
+                                    th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             <tr class="days">
-                                <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
+                                <th th:each="day : ${daysOfWeek}" th:text="${day}"
+                                    th:classappend="${day.contains('土')} ? 'saturday' : (${day.contains('日')} ? 'sunday' : '')">
+                                </th>
+
                             </tr>
                         </thead>
+                        <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                            <tr th:each="stock: ${stocks}">
+                                <td th:text="${stock[0].title}"></td> <!-- 一つ目の値 -->
+                                <td th:text="${stock[0].stockCount}"></td> <!-- 二つ目の値 -->
+                                <td th:each="rentalstock : ${stock}">
+                                    <span th:if="${rentalstock.countAvailableRental le 0}" th:text="${'×'}"></span>
+                                    <a th:if="${rentalstock.countAvailableRental gt 0}"
+                                        th:href="@{/rental/add(stockId=${rentalstock.stockId}, expectedRentalOn=${#dates.format(rentalstock.expectedRentalOn, 'yyyy-MM-dd')})}"
+                                        th:text="${rentalstock.countAvailableRental}"></a>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/stock/index.html
+++ b/src/main/resources/templates/stock/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫一覧',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/index.css}" />
     <script type="text/javascript" th:src="@{/js/stock/index.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -14,7 +16,7 @@
                 <div class="page_title">在庫一覧</div>
                 <div class="add_btn">
                     <a th:href="@{/stock/add}">
-                        <span><img src="../images/icons/add.png" alt="add"/></span>
+                        <span><img src="../images/icons/add.png" alt="add" /></span>
                         <span>在庫登録</span>
                     </a>
                 </div>
@@ -30,13 +32,17 @@
                         <tr th:each="stock : ${stockList}" th:object="${stock}">
                             <td>
                                 <div class="stock_item_menu">
-                                    <div><a th:href="@{/stock/{id}/edit(id=*{id})}"><img src="../images/icons/edit.png" alt="edit"/></a></div>
-                                    <div><a href="#" class="" onClick="openDeleteModal()"><img src="../images/icons/trash.png" alt="trash"/></a></div>
+                                    <div><a th:href="@{/stock/{id}/edit(id=*{id})}"><img src="../images/icons/edit.png"
+                                                alt="edit" /></a></div>
+                                    <div><a href="#" class="" onClick="openDeleteModal()"><img
+                                                src="../images/icons/trash.png" alt="trash" /></a></div>
                                     <div><a th:href="@{/stock/{id}(id=*{id})}" th:text="*{id}"></a></div>
                                 </div>
                             </td>
                             <td th:text="*{bookMst.title}"></td>
-                            <td th:text="${stock.status == 0 && (#lists.isEmpty(stock.rentalManages) || stock.rentalManages[0].status != 1) ? '利用可' : '利用不可'}"></td>
+                            <td
+                                th:text="${stock.status == 0 && (#lists.isEmpty(stock.rentalManages) || stock.rentalManages[0].status != 1) ? '利用可' : '利用不可'}">
+                            </td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
##概要 
*在庫カレンダー機能の追加
*generatevalueメソッドで書籍名、在庫数、日ごとの貸出可能在庫数の処理
*Repositoryで書籍名、在庫数、貸出可能在庫数、在庫管理番号を取得するSQL文
*calendarDtoの作成
*calendarのHTMLの修正

##テスト証跡 
*在庫カレンダーの書籍名、在庫数、日ごとの貸出可能在庫数が正しく表示されているか
*貸出可能在庫数のリンクで貸出登録画面に遷移し、貸出予定日と在庫管理番号がセットされているか

以上を確認していただきたいです。よろしくお願いいたします。